### PR TITLE
Add web-based People Farm Helper game

### DIFF
--- a/people-farm-game/README.md
+++ b/people-farm-game/README.md
@@ -1,0 +1,10 @@
+# People Farm Helper Game
+
+Simple web3 game where feeding and adopting virtual animals sends Solana donations to People Farm.
+
+## Local setup
+1. Syntax check: `node --check game.js`
+2. Serve the folder: `python3 -m http.server`
+3. Open `http://localhost:8000/` in your browser.
+
+Replace the placeholder wallet addresses in `game.js` before deploying.

--- a/people-farm-game/game.js
+++ b/people-farm-game/game.js
@@ -1,0 +1,133 @@
+const PEOPLE_FARM_WALLET = "PEOPLE_FARM_WALLET_ADDRESS";
+const REWARD_POOL_WALLET = "REWARD_POOL_WALLET_ADDRESS";
+
+const animals = [
+  { name: "Rani", story: "Rescued calf", health: 25, costFeed: 0.01, costMed: 0.02 }
+];
+
+const adoptableAnimals = [];
+let provider;
+
+window.addEventListener('DOMContentLoaded', () => {
+  provider = window.solana;
+  document.getElementById('connect-button').onclick = connectWallet;
+  document.getElementById('adopt-button').onclick = () => {
+    renderAdoptionList();
+    showScreen('adoption-screen');
+  };
+  document.getElementById('back-button').onclick = () => showScreen('screen-main');
+  document.getElementById('close-popup').onclick = closePopup;
+  initFarm();
+});
+
+function showScreen(id) {
+  document.querySelectorAll('.screen').forEach(s => s.classList.remove('active'));
+  document.getElementById(id).classList.add('active');
+}
+
+async function connectWallet() {
+  if (!provider) {
+    alert('Phantom Wallet not found');
+    return;
+  }
+  try {
+    await provider.connect();
+    showScreen('screen-main');
+  } catch (err) {
+    console.error(err);
+  }
+}
+
+function initFarm() {
+  const newArrivals = document.getElementById('new-arrivals');
+  animals.forEach(a => {
+    const div = document.createElement('div');
+    div.className = 'animal';
+    div.textContent = a.name;
+    div.onclick = () => openAnimalPopup(a);
+    newArrivals.appendChild(div);
+  });
+}
+
+function openAnimalPopup(animal) {
+  document.getElementById('animal-name').textContent = animal.name;
+  document.getElementById('animal-story').textContent = animal.story;
+  document.getElementById('health-bar').style.width = animal.health + '%';
+  const feedBtn = document.getElementById('feed-button');
+  feedBtn.textContent = `Feed (${animal.costFeed} SOL)`;
+  feedBtn.onclick = () => donate(animal.costFeed, animal);
+  const medBtn = document.getElementById('medicine-button');
+  medBtn.textContent = `Provide Medicine (${animal.costMed} SOL)`;
+  medBtn.onclick = () => donate(animal.costMed, animal);
+  document.getElementById('animal-popup').classList.remove('hidden');
+}
+
+function closePopup() {
+  document.getElementById('animal-popup').classList.add('hidden');
+}
+
+async function donate(amount, animal) {
+  if (!provider?.publicKey) {
+    alert('Connect wallet first');
+    return;
+  }
+  const connection = new solanaWeb3.Connection(solanaWeb3.clusterApiUrl('devnet'));
+  const userPubkey = provider.publicKey;
+  const donationPubkey = new solanaWeb3.PublicKey(PEOPLE_FARM_WALLET);
+  const rewardPubkey = new solanaWeb3.PublicKey(REWARD_POOL_WALLET);
+  const lamports = Math.round(amount * solanaWeb3.LAMPORTS_PER_SOL);
+  const donationLamports = Math.round(lamports * 0.9);
+  const rewardLamports = lamports - donationLamports;
+
+  const transaction = new solanaWeb3.Transaction().add(
+    solanaWeb3.SystemProgram.transfer({
+      fromPubkey: userPubkey,
+      toPubkey: donationPubkey,
+      lamports: donationLamports
+    }),
+    solanaWeb3.SystemProgram.transfer({
+      fromPubkey: userPubkey,
+      toPubkey: rewardPubkey,
+      lamports: rewardLamports
+    })
+  );
+
+  try {
+    const { signature } = await provider.signAndSendTransaction(transaction);
+    await connection.confirmTransaction(signature);
+    animal.health = Math.min(100, animal.health + 25);
+    document.getElementById('health-bar').style.width = animal.health + '%';
+    if (animal.health >= 100 && !adoptableAnimals.includes(animal)) {
+      adoptableAnimals.push(animal);
+      renderAdoptable();
+    }
+  } catch (err) {
+    console.error(err);
+  }
+}
+
+function renderAdoptable() {
+  const list = document.getElementById('adoptable');
+  list.innerHTML = '';
+  adoptableAnimals.forEach(a => {
+    const div = document.createElement('div');
+    div.className = 'animal';
+    div.textContent = `${a.name} (healthy)`;
+    list.appendChild(div);
+  });
+}
+
+function renderAdoptionList() {
+  const list = document.getElementById('adoption-list');
+  list.innerHTML = '';
+  adoptableAnimals.forEach(a => {
+    const div = document.createElement('div');
+    div.className = 'animal';
+    div.textContent = a.name;
+    const btn = document.createElement('button');
+    btn.textContent = 'Adopt Me! (0.05 SOL)';
+    btn.onclick = () => donate(0.05, a);
+    div.appendChild(btn);
+    list.appendChild(div);
+  });
+}

--- a/people-farm-game/index.html
+++ b/people-farm-game/index.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8"/>
+    <title>People Farm Helper</title>
+    <link rel="stylesheet" href="styles.css">
+    <script src="https://unpkg.com/@solana/web3.js@latest/lib/index.iife.js"></script>
+    <script defer src="game.js"></script>
+</head>
+<body>
+<div id="screen-welcome" class="screen active">
+    <h1>People Farm Helper</h1>
+    <div class="animal-emoji">🐄</div>
+    <p>Welcome! Help real animals at People Farm India. Connect your wallet to get started.</p>
+    <button id="connect-button">Connect Phantom Wallet</button>
+</div>
+
+<div id="screen-main" class="screen">
+    <div class="actions">
+        <button id="adopt-button">Adopt</button>
+    </div>
+    <div class="farm">
+        <h2>New Arrivals</h2>
+        <div id="new-arrivals"></div>
+        <h2>Ready for Adoption</h2>
+        <div id="adoptable"></div>
+    </div>
+</div>
+
+<div id="animal-popup" class="modal hidden">
+    <div class="modal-content">
+        <span id="close-popup" class="close">&times;</span>
+        <h3 id="animal-name"></h3>
+        <p id="animal-story"></p>
+        <div class="progress">
+            <div id="health-bar"></div>
+        </div>
+        <button id="feed-button"></button>
+        <button id="medicine-button"></button>
+    </div>
+</div>
+
+<div id="adoption-screen" class="screen">
+    <h2>Virtual Adoption Center</h2>
+    <div id="adoption-list"></div>
+    <button id="back-button">Back</button>
+</div>
+</body>
+</html>

--- a/people-farm-game/styles.css
+++ b/people-farm-game/styles.css
@@ -1,0 +1,13 @@
+body { font-family: sans-serif; background:#d0f0c0; text-align:center; }
+.screen { display:none; }
+.screen.active { display:block; }
+.actions { position:fixed; left:10px; top:10px; }
+.farm { margin-top:50px; }
+.animal { cursor:pointer; display:inline-block; margin:10px; padding:10px; border:1px solid #333; background:#fff; }
+.animal-emoji { font-size:64px; }
+.modal { position:fixed; top:0; left:0; right:0; bottom:0; background:rgba(0,0,0,0.5); display:flex; align-items:center; justify-content:center; }
+.modal.hidden { display:none; }
+.modal-content { background:#fff; padding:20px; border-radius:8px; width:300px; }
+.progress { width:100%; background:#ccc; height:20px; margin:10px 0; }
+#health-bar { background:#0c0; width:0%; height:100%; }
+.close { cursor:pointer; float:right; }


### PR DESCRIPTION
## Summary
- Add People Farm Helper web app with welcome screen, wallet connect, and adoption interfaces
- Implement Solana donation function that splits funds between People Farm and reward pool while updating animal health
- Style game with simple pixel-art inspired layout and add README instructions

## Testing
- `node --check people-farm-game/game.js`


------
https://chatgpt.com/codex/tasks/task_e_68b16b1bab148320ad4a9eacbe3dc7c7